### PR TITLE
Update to Minecraft 1.21.9

### DIFF
--- a/spyglass.json
+++ b/spyglass.json
@@ -1,5 +1,5 @@
 {
   "env": {
-    "gameVersion": "1.21.6"
+    "gameVersion": "1.21.9"
   }
 }

--- a/src/plugins/output.py
+++ b/src/plugins/output.py
@@ -3,12 +3,12 @@ from beet import Context
 from bolt import Module
 import os
 
-VERSION = os.getenv("VERSION", "1.21.6")
-MAJOR_VERSION = "1_21_6-1_21_8"
+VERSION = os.getenv("VERSION", "1.21.9")
+MAJOR_VERSION = "1_21_6-1_21_9"
 FORMAT = 80
-FORMATS = [80,81]
+FORMATS = [80,81,82]
 RP_FORMAT = 63
-RP_FORMATS = [63,64]
+RP_FORMATS = [63,64,65]
 
 def beet_default(ctx: Context):
 	"""Saves the datapack to the ./out folder."""

--- a/src/plugins/worldgen/compat.py
+++ b/src/plugins/worldgen/compat.py
@@ -8,8 +8,8 @@ from .get_empty_biomes import geode_purge
 from typing import Any
 import os
 
-VERSION = os.getenv('VERSION', '1.21.6')
-MAJOR_VERSION = "1_21_6-1_21_8"
+VERSION = os.getenv('VERSION', '1.21.9')
+MAJOR_VERSION = "1_21_6-1_21_9"
 
 def terralith(ctx: Context):
   url = "https://cdn.modrinth.com/data/8oi3bsk5/versions/4LsxILTH/Terralith_1.21_v2.5.5.zip"

--- a/src/plugins/worldgen/get_empty_biomes.py
+++ b/src/plugins/worldgen/get_empty_biomes.py
@@ -4,8 +4,8 @@ from beet.contrib.worldgen import WorldgenBiome, WorldgenPlacedFeature
 import os
 import requests
 
-VERSION = os.getenv('VERSION', '1.21.6')
-MAJOR_VERSION = "1_21_6-1_21_8"
+VERSION = os.getenv('VERSION', '1.21.9')
+MAJOR_VERSION = "1_21_6-1_21_9"
 NAME = "skyvoid_worldgen"      # name of the module
 DIR = f"worldgen/{NAME}/data"
 TEMP_PATH = f"worldgen/{NAME}/temp_files"

--- a/src/plugins/worldgen/get_empty_structures.py
+++ b/src/plugins/worldgen/get_empty_structures.py
@@ -4,7 +4,7 @@ import re
 from nbtlib import * # type: ignore
 import os
 
-VERSION = os.getenv('VERSION', '1.21.6')
+VERSION = os.getenv('VERSION', '1.21.9')
 NAME = "skyvoid_worldgen"      # name of the module
 DIR = f"worldgen/{NAME}/data"
 TEMP_PATH = f"worldgen/{NAME}/temp_files"


### PR DESCRIPTION
## Changes
- Updated game version from 1.21.6 to 1.21.9
- Extended pack format support to include formats 80-82 (data packs) and 63-65 (resource packs)
- Updated MAJOR_VERSION range to 1_21_6-1_21_9 for broader compatibility
- Maintains backward compatibility with Minecraft 1.21.6-1.21.8

## Files Modified
- `spyglass.json` - Updated gameVersion to 1.21.9
- `src/plugins/output.py` - Extended format support and version ranges
- `src/plugins/worldgen/compat.py` - Updated version strings
- `src/plugins/worldgen/get_empty_biomes.py` - Updated version strings
- `src/plugins/worldgen/get_empty_structures.py` - Updated version strings

This minimal change ensures the SkyBlock Collection data packs work with Minecraft 1.21.9 while maintaining compatibility with previous 1.21.x versions.