### PR TITLE
Fix terminology in README for SkyBlock Dirt

### DIFF
--- a/src/bundles/skyvoid_skyblock_dirt/README.md
+++ b/src/bundles/skyvoid_skyblock_dirt/README.md
@@ -7,7 +7,7 @@ Support: [![BMC Badge](https://img.shields.io/badge/_%20-Buy%20Me%20a%20Coffee-b
 ## SkyBlock Dirt Hardcore (HardBlock)
 This data pack generates a classic skyblock island without a tree or chest (only dirt) at the bottom of the world in a Snowy Taiga biome (at Y=-64). This is similar to [Vanilla One Block](https://smithed.net/packs/vanilla_one_block), but is possible to play in hardcore mode. The world spawn point will be moved to the location of the island at Y=0, so mobs will be able to spawn on the island. The locator will fail if there isn't a snowy taiga within 2000 blocks, so some worlds will fail to generate the island.
 
-The worldgen data pack infinitely generates a void world with properties akin to the [original SkyBlock](https://skyblock.net/). This means all structures (that matter) will generate with their bounding boxes, but no blocks. These structures will generate at the same location as if the world with the same seed was generated with normal terrain. The only blocks that generate apart from the starter islands are End portals and sculk sensors.
+The worldgen data pack infinitely generates a void world with properties akin to the [original SkyBlock](https://skyblock.net/). This means all structures (that matter) will generate with their bounding boxes, but no blocks. These structures will generate at the same location as if the world with the same seed was generated with normal terrain. The only blocks that generate apart from the starter islands are End portals and sculk shriekers.
 
 ### Structures
 Structure bounding boxes that are important in SkyBlock will generate at the same coordinates along with some entities as they would in a normal world with the same seed:


### PR DESCRIPTION
Updated the README to replace 'sculk sensors' with 'sculk shriekers' for accuracy.