### PR TITLE
fix: broken link to worldgen

### DIFF
--- a/src/packs/starter_islands/skyvoid_standard_skyblock/README.md
+++ b/src/packs/starter_islands/skyvoid_standard_skyblock/README.md
@@ -7,4 +7,4 @@ This island will generate with 54 dirt, 26 grass blocks, 1 bedrock (at world spa
 The nether island will generate with 40 netherrack, 7 crimson nylium, 7 warped nylium, 2 soul sand, 2 nether wart, and 14 obsidian for the portal.
 
 ### Dependencies
-[Sky Void Worldgen](https://github.com/BPR02/SkyBlock_Collection/blob/main/src/worldgen) must be installed alongside this data pack. 
+[Sky Void Worldgen](https://github.com/BPR02/SkyBlock_Collection/blob/main/src/packs/worldgen) must be installed alongside this data pack. 


### PR DESCRIPTION
Haven't checked if any of the other packs directories have the same broken link yet I believe it should be the only one